### PR TITLE
パッケージ公開支援とライセンスの明確化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 build/*
 
 src/test/data/output/*
+src/main/resources/sphinx.plugin.release.properties

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,22 @@
-apply plugin: 'groovy'
+plugins {
+    // bintray
+    id "com.jfrog.bintray" version "1.6"
+}
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+apply plugin: 'groovy'
+apply plugin: 'maven'
+apply plugin: 'com.jfrog.bintray'
+
+group = projectGroup
+version = currentVersion
+
+compileGroovy {
+    sourceCompatibility = '1.8'
+    targetCompatibility = '1.8'
+}
 
 repositories {
-  mavenCentral()
+  jcenter()
 }
 
 dependencies {
@@ -13,5 +25,31 @@ dependencies {
   testCompile ('org.spockframework:spock-core:0.7-groovy-2.0') {
     exclude module: 'groovy-all'
   }
+}
+
+task sourceJar(type: Jar) {
+    from sourceSets.main.allSource
+    classifier = 'sources'
+}
+
+task createReleasePropertiesFile(type:Exec) {
+    String fileName = 'sphinx.plugin.release.properties'
+    println "Creating $fileName"
+    String fileContent = "version=$currentVersion"
+    (new File("$rootDir/src/main/resources/$fileName")).write(fileContent)
+}
+
+artifacts {
+    archives jar
+    archives sourceJar
+}
+
+task wrapper(type: Wrapper, description: 'Gradle Wrapper task') {
+    gradleVersion = '3.0'
+}
+
+if (gradle.startParameter.taskNames.contains('uploadArchives') ||
+    gradle.startParameter.taskNames.contains('bintrayUpload')) {
+  apply from: 'build.publish.gradle'
 }
 

--- a/build.publish.gradle
+++ b/build.publish.gradle
@@ -1,0 +1,106 @@
+apply plugin: 'maven'
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+// Ask password for GnuPG singing.
+boolean validProperty(propertyName) {
+  try { project.property(propertyName) != null }
+  catch (MissingPropertyException) { false }
+}
+assert validProperty('signing.keyId'),             'properties for signing must be provided'
+assert validProperty('signing.secretKeyRingFile'), 'properties for signing must be provided'
+
+String askPassword(prompt) {
+  "${System.console().readPassword(prompt)}"
+}
+ext.'signing.password' = askPassword("Enter password for PGP key ${property('signing.keyId')}: ")
+
+signing {
+  sign configurations.archives
+}
+
+install {
+    repositories.mavenInstaller {
+        pom.project {
+            name project.name
+            packaging 'jar'
+            description projectDesc
+            url projectUrl
+            version currentVersion
+            licenses {
+                license {
+                    name licenseName
+                    url licenseUrl
+                    distribution 'repo'
+                }
+            }
+            scm {
+                url githubUrl
+                connection "scm:git:${githubUrl}"
+                developerConnection "scm:git:${githubUrl}"
+            }
+            developers {
+                developer {
+                    id developerId
+                    name developerName
+                    email developerEmail
+                }
+            }
+        }
+    }
+}
+
+bintray {
+    user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
+    key = project.hasProperty('bintrayApiKey') ? project.property('bintrayApiKey') : System.getenv('BINTRAY_API_KEY')
+    dryRun = false
+    configurations = ['archives']
+    pkg {
+        repo = 'maven'
+        name = projectName
+        desc = projectDesc
+        websiteUrl = projectUrl
+        issueTrackerUrl = projectUrl + '/issues'
+        vcsUrl = projectUrl
+        githubRepo = githubUser + '/' + githubRepository
+        licenses = [licenseCName]
+        labels = ['Sphinx', 'Gradle']
+        publicDownloadNumbers = true
+    }
+}
+
+// maven publish to local repository.(for test)
+uploadArchives {
+    repositories.mavenDeployer {
+        // for local maven
+        repository url: "file://$System.env.HOME/.m2/repository"
+        beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+        pom.project {
+            name project.name
+            packaging 'jar'
+            description projectDesc
+            url projectUrl
+            version currentVersion
+            licenses {
+                license {
+                    name licenseName
+                    url licenseUrl
+                    distribution 'repo'
+                }
+            }
+            scm {
+                url githubUrl
+                connection "scm:git:${githubUrl}"
+                developerConnection "scm:git:${githubUrl}"
+            }
+            developers {
+                developer {
+                    id developerId
+                    name developerName
+                    email developerEmail
+                }
+            }
+        }
+    }
+}
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,17 @@
+currentVersion=0.1
+projectTag=v0.1
+projectGroup=siosio
+projectOwner=siosio
+projectReleaseBody='pre-release'
+projectUrl=https://github.com/siosio/Sphinx-GradlePlugin
+githubUrl=git@github.com:siosio/Sphinx-GradlePlugin.git
+githubUser=siosio
+developerId=siosio
+developerName='siosio'
+developerEmail='siosio@example.com'
+githubRepository=Sphinx-GradlePlugin
+projectName=Sphinx-GradlePlugin
+projectDesc=Sphinx plugin for Gradle
+licenseCName=Apache-2.0
+licenseName='Apache 2.0 License'
+licenseUrl=https://gradle.org/license/

--- a/gradle.properties.template
+++ b/gradle.properties.template
@@ -1,0 +1,10 @@
+# template for $HOME/.gradle/gradle.properties
+bintrayUser=hoge
+bintrayApiKey=1234567890abcdef
+signing.keyId=0123456
+signing.secretKeyRingFile=/home/user/.gnupg/secring.gpg
+sonatypeUsername=hoge
+sonatypeFullname='Full Name'
+sonatypeKey=abcdAjf
+sonatypeToken=hogehogefugafuga
+githubToken=1234567890abcdef

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.0-bin.zip


### PR DESCRIPTION
bintrayやgithub releasesへのパッケージ公開のためのgradleスクリプトの追加.

- jarファイルをGnuPGで署名
- リリース作業時のみパスフェラーズを入力要求
- Mavenとjcenter/bintrayへの公開対応
- 試験用にlocal Mavenリポジトリにパッケージ追加可能
- ライセンスとしてGradleのライセンスであるApache 2.0を記載
- Gradleバージョンを最新化

適宜 gradle.propertiesを設定してください

Signed-off-by: Hiroshi Miura <miurahr@linux.com>